### PR TITLE
Add `display: inline-flex` to .gs-u-clearfix 

### DIFF
--- a/lib/utilities/_clearfix.scss
+++ b/lib/utilities/_clearfix.scss
@@ -10,4 +10,9 @@
  */
 .gs-u-clearfix {
     @include clearfix;
+
+    // When the clearfix pseudo-element is a flex child, it is brought into the
+    // flex layout and given dimensions. To avoid the extra space created by this,
+    // we can collapse the element with display: inline-flex.
+    display: inline-flex;
 }


### PR DESCRIPTION
This prevents extra spacing when clearing floats within a flexbox container.
