### PR TITLE
Adding in the class 'body-copy' to non-latin scripts

### DIFF
--- a/lib/settings/scripts/arabic/_config.scss
+++ b/lib/settings/scripts/arabic/_config.scss
@@ -1,6 +1,6 @@
 @if $script == 'arabic' {
     $rtl: true !global;
-    // the gel-body-copy used on live pages was undefined for world-service sites (non-latin script)
+    // the gel-body-copy class used on live pages was undefined for world-service sites (non-latin script)
     // so after talking to UX the same settings as pica were used for the new class
     $pica: (
         'group-a': (

--- a/lib/settings/scripts/bengali/_config.scss
+++ b/lib/settings/scripts/bengali/_config.scss
@@ -1,5 +1,5 @@
 @if $script == 'bengali' {
-    // the gel-body-copy used on live pages was undefined for world-service sites (non-latin script)
+    // the gel-body-copy class used on live pages was undefined for world-service sites (non-latin script)
     // so after talking to UX the same settings as pica were used for the new class
     $pica: (
         'group-a': (

--- a/lib/settings/scripts/burmese/_config.scss
+++ b/lib/settings/scripts/burmese/_config.scss
@@ -1,5 +1,5 @@
 @if $script == 'burmese' {
-    // the gel-body-copy used on live pages was undefined for world-service sites (non-latin script)
+    // the gel-body-copy class used on live pages was undefined for world-service sites (non-latin script)
     // so after talking to UX the same settings as pica were used for the new class
     $pica: (
         'group-a': (

--- a/lib/settings/scripts/chinese/_config.scss
+++ b/lib/settings/scripts/chinese/_config.scss
@@ -1,5 +1,5 @@
 @if $script == 'chinese' {
-    // the gel-body-copy used on live pages was undefined for world-service sites (non-latin script)
+    // the gel-body-copy class used on live pages was undefined for world-service sites (non-latin script)
     // so after talking to UX the same settings as pica were used for the new class
     $pica: (
         'group-a': (

--- a/lib/settings/scripts/cyrillic/_config.scss
+++ b/lib/settings/scripts/cyrillic/_config.scss
@@ -1,5 +1,5 @@
 @if $script == 'cyrillic' {
-    // the gel-body-copy used on live pages was undefined for world-service sites (non-latin script)
+    // the gel-body-copy class used on live pages was undefined for world-service sites (non-latin script)
     // so after talking to UX the same settings as pica were used for the new class
     $pica: (
         'group-a': (

--- a/lib/settings/scripts/hindi/_config.scss
+++ b/lib/settings/scripts/hindi/_config.scss
@@ -1,5 +1,5 @@
 @if $script == 'hindi' {
-    // the gel-body-copy used on live pages was undefined for world-service sites (non-latin script)
+    // the gel-body-copy class used on live pages was undefined for world-service sites (non-latin script)
     // so after talking to UX the same settings as pica were used for the new class
     $pica: (
         'group-a': (

--- a/lib/settings/scripts/japanese/_config.scss
+++ b/lib/settings/scripts/japanese/_config.scss
@@ -1,5 +1,5 @@
 @if $script == 'japanese' {
-    // the gel-body-copy used on live pages was undefined for world-service sites (non-latin script)
+    // the gel-body-copy class used on live pages was undefined for world-service sites (non-latin script)
     // so after talking to UX the same settings as pica were used for the new class
     $pica: (
         'group-a': (

--- a/lib/settings/scripts/sinhala/_config.scss
+++ b/lib/settings/scripts/sinhala/_config.scss
@@ -1,5 +1,5 @@
 @if $script == 'sinhala' {
-    // the gel-body-copy used on live pages was undefined for world-service sites (non-latin script)
+    // the gel-body-copy class used on live pages was undefined for world-service sites (non-latin script)
     // so after talking to UX the same settings as pica were used for the new class
     $pica: (
         'group-a': (

--- a/lib/settings/scripts/tamil/_config.scss
+++ b/lib/settings/scripts/tamil/_config.scss
@@ -1,5 +1,5 @@
 @if $script == 'tamil' {
-    // the gel-body-copy used on live pages was undefined for world-service sites (non-latin script)
+    // the gel-body-copy class used on live pages was undefined for world-service sites (non-latin script)
     // so after talking to UX the same settings as pica were used for the new class
     $pica: (
         'group-a': (


### PR DESCRIPTION
https://jira.dev.bbc.co.uk/browse/WSRESPONSIVE-4860
- Adding a new class to the World Service config.
- This class was already in use on the News site but didn't have a world service counterpart, causing the font-size on the non-latin live pages to default to a small text size different from what was used by the equivalent article pages.
- Gel-body-copy after discussion with UX was given the same font settings as pica (which is used on the article pages)