### PR TITLE
LIVESCHEDULE-5058 - Support seperate href element on faux block link.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 | Version | Description |
 |---------|-------------|
+| 4.1.2   | Update faux-block link to support seperate href element as well as :before. |
 | 4.1.1   | Bump z-index on faux block links to make them more robust. |
 | 4.1.0   | Updating Bullet pattern with the Essential modifier. |
 | 4.0.0   | Updating Bullet to show icon on core. Updating Faux Block Link for IE compatibility. |

--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,5 @@
   "dependencies": {
     "gs-sass-tools": "git@github.com:bbc/gs-sass-tools.git#^4.1.2"
   },
-  "version": "4.1.1"
+  "version": "4.1.2"
 }

--- a/lib/objects/_faux-block-link.scss
+++ b/lib/objects/_faux-block-link.scss
@@ -66,6 +66,48 @@ Our implementation is based on http://codepen.io/IschaGast/pen/Qjxpxo
     }
 }
 
+/**
+ * This class allows you to have a seperate overlay href rather than using :before
+ * Useful if you have a position relative between the link and the container div where the .gs-o-faux-block-link
+ * should overlay.
+ */
+.gs-o-faux-block-link .gs-o-faux-block-link__overlay {
+
+    display: none;
+    visibility: hidden;
+
+    @if $enhanced {
+        @include ie-background-fix;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+
+        display: block;
+        visibility: visible;
+
+        overflow: hidden;
+        text-indent: 200%;
+
+        white-space: nowrap;
+    }
+}
+
+/**
+ * Increased specificity so it trumps ".faux-block-link a"
+ *
+ * 1. IE Fix - Elements have a solid black background in high contrast mode.
+ */
+.gs-o-faux-block-link__overlay.gs-o-faux-block-link__overlay {
+
+    position: absolute;
+    z-index: 0;
+
+    .lt-ie9 & {
+        opacity: 0; /* [1] */
+    }
+}
+
 // only applies to IE 10
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
     .gs-o-faux-block-link .gs-o-faux-block-link__overlay-link:before {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbc-grandstand",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "The BBC Grandstand CSS Framework is used by Sport and Live components",
   "main": "_grandstand.scss",
   "scripts": {


### PR DESCRIPTION
Along the way we removed the ability to have a separate href element that overlays the component and instead use a `:before`. This is great in most cases but where a component has a position relative set between the link and the container of the component this method won't work so we need to bring back the "old" way for these elements. The current implementation breaks the dynamic promo and V2 pages so this makes it so things don't break. In the dynamic promo case this is the only faux-block link solution that will work because of the trickery around how we've created the line and the use of position relative on certain elements.