### PR TITLE
Use Grunt to build dist/ so that building multiple scripts is easier

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-    "directory": "../"
+    "directory": "bower_components"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,32 @@
+module.exports = function (grunt) {
+    grunt.loadNpmTasks('grunt-sass');
+
+    grunt.initConfig({
+        sass: {
+            dev: {
+                expand: true,
+                cwd: 'src',
+                src: ['**/*.scss', '!**/_*.scss', '!bower_components/**/*.scss', '!node_modules/**/*.scss'],
+                dest: './dist',
+                ext: '.css',
+                options: {
+                    outputStyle: 'expanded'
+                }
+            },
+            compressed: {
+                expand: true,
+                cwd: 'src',
+                src: ['**/*.scss', '!**/_*.scss', '!bower_components/**/*.scss', '!node_modules/**/*.scss'],
+                dest: './dist',
+                ext: '.min.css',
+                options: {
+                    outputStyle: 'compressed'
+                }
+            }
+        }
+    });
+
+    grunt.registerTask('build', ['sass']);
+    grunt.registerTask('default', ['build']);
+}
+

--- a/_grandstand.scss
+++ b/_grandstand.scss
@@ -5,7 +5,7 @@
 // settings and tools
 @import 'lib/settings/global';
 @import 'lib/settings/l10n';
-@import '../gs-sass-tools/sass-tools';
+@import 'bower_components/gs-sass-tools/sass-tools';
 
 // objects
 @import 'lib/objects/bullet';

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The BBC Grandstand CSS Framework is used by Sport and Live components",
   "main": "_grandstand.scss",
   "scripts": {
+    "start": "npm install && bower install",
     "build": "grunt build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "The BBC Grandstand CSS Framework is used by Sport and Live components",
   "main": "_grandstand.scss",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "dist": "bower install && node-sass src/bbc-grandstand.scss dist/bbc-grandstand.min.css --output-style=compressed --sourcemap=none && node-sass src/bbc-grandstand.scss dist/bbc-grandstand.css --output-style=expanded --sourcemap=none"
+    "build": "grunt build",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,9 @@
   "homepage": "http://bbc.github.io/grandstand/",
   "devDependencies": {
     "bower": "^1.7.9",
-    "node-sass": "^3.7.0"
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-sass": "^2.0.0",
+    "node-sass": "^4.5.0"
   }
 }


### PR DESCRIPTION
Rather than running node-sass directly through `npm run dist`, it makes more sense to set up a proper build task. This makes it much easier to compile all of the script variants introduced in #70.