### PR TITLE
Minify CSS with cssmin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-sass');
+    grunt.loadNpmTasks('grunt-contrib-cssmin');
 
     grunt.initConfig({
         sass: {
@@ -12,21 +13,23 @@ module.exports = function (grunt) {
                 options: {
                     outputStyle: 'expanded'
                 }
-            },
-            compressed: {
-                expand: true,
-                cwd: 'src',
-                src: ['**/*.scss', '!**/_*.scss', '!bower_components/**/*.scss', '!node_modules/**/*.scss'],
-                dest: './dist',
-                ext: '.min.css',
-                options: {
-                    outputStyle: 'compressed'
-                }
             }
-        }
+        },
+
+        cssmin: {
+            min: {
+                files: [{
+                    expand: true,
+                    cwd: 'dist',
+                    src: ['*.min.css'],
+                    dest: 'dist',
+                    ext: '.min.css'
+                }]
+            }
+        },
     });
 
-    grunt.registerTask('build', ['sass']);
+    grunt.registerTask('build', ['sass', 'cssmin']);
     grunt.registerTask('default', ['build']);
 }
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bower": "^1.7.9",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
+    "grunt-contrib-cssmin": "^1.0.0",
     "grunt-sass": "^2.0.0",
     "node-sass": "^4.5.0"
   }


### PR DESCRIPTION
This uses clean-css under the hood, which performs some great optimisations. I've purposely chosen to use grunt-contrib-cssmin@^1.0.0 instead of ^2.0.0 because the results are significantly better.

| File           | Sass "compressed" size | clean-css size |
|----------------|------------------------|----------------|
| arabic.min.css | 88638 bytes            | 77846 bytes    |
| latin.min.css  | 88272 bytes            | 77457 bytes    |
| thai.min.css   | 88216 bytes            | 77404 bytes    |

