### PR TITLE
Use gs-sass-tools @ ^5.0.2 to pull in gel-grid @ ^3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 | Version | Description |
 |---------|-------------|
+| 5.0.0   | Use gs-sass-tools @ ^5.0.2 to pull in gel-grid @ ^3.0.0 |
 | 4.1.4   | IE improvements to faux block link |
 | 4.1.3   | Add clear classes |
 | 4.1.2   | Update faux-block link to support seperate href element as well as :before. |

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "authors": [
     "Shaun Bent <shaun.bent@bbc.co.uk>"
   ],
-  "description": "The BBC Grandstand CSS Framework is used by Sport and Live components",
+  "description": "The BBC Grandstand CSS Framework is used by Sport, Live and News components",
   "main": "_grandstand.scss",
   "license": "MIT",
   "ignore": [
@@ -15,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "gs-sass-tools": "git@github.com:bbc/gs-sass-tools.git#^4.1.2"
+    "gs-sass-tools": "git@github.com:bbc/gs-sass-tools.git#^5.0.2"
   },
-  "version": "4.1.4"
+  "version": "5.0.0"
 }


### PR DESCRIPTION
👋  @shaunbent @mintuz @wildlyinaccurate @sareh @greenc05 

This pulls in three main changes:
 * https://github.com/bbc/gs-sass-tools/pull/29 - `gel-grid @ ^3.0.0`
 * https://github.com/bbc/gs-sass-tools/pull/31 - a new hex value for `$nw-c-stone-dark` 
* https://github.com/bbc/gs-sass-tools/pull/32 - a new colour `$nw-c-puddle: #E4EDF7`