### PR TITLE
liveschedule-5896/add-border-utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 | Version | Description |
 |---------|-------------|
+| 5.1.0   | Created a utility for borders |
 | 5.0.4   | Update gs-sass-tools to version 5.0.5 |
 | 5.0.3   | Use latin script for amharic, tigrinya and gujarati services |
 | 5.0.2   | Add ethiopic script for use by amharic and tigrinya services |

--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,5 @@
   "dependencies": {
     "gs-sass-tools": "git@github.com:bbc/gs-sass-tools.git#^5.0.5"
   },
-  "version": "5.0.4"
+  "version": "5.1.0"
 }

--- a/lib/utilities/_border.scss
+++ b/lib/utilities/_border.scss
@@ -1,0 +1,12 @@
+/*------------------------------------*\
+    # BORDER
+\*------------------------------------*/
+
+/**
+ * A utility for managing the borders of elements
+ */
+
+.gs-u-br0 {
+  border-radius: 0;
+}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbc-grandstand",
-  "version": "5.0.4",
+  "version": "5.1.0",
   "description": "The BBC Grandstand CSS Framework is used by Sport and Live components",
   "main": "_grandstand.scss",
   "scripts": {


### PR DESCRIPTION
Added a new utility file to modify borders of elements as part of work for: https://jira.dev.bbc.co.uk/browse/LIVESCHEDULE-5896

Due to a recent Chrome update, several buttons on the live/events pages now have rounded borders. Added a utility class gs-u-br0 to explicitly set the border radius to 0.