### PR TITLE
Add link object and link class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 | Version | Description |
 |---------|-------------|
+| 5.3.0   | Add link object and commonly used link class |
 | 5.2.1   | Add helper for reduced motion |
 | 5.1.1   | Use gs-sass-tools @ ^5.0.8 to pull in social colour changes |
 | 5.1.0   | Add alt++ to spacing utility |

--- a/_grandstand.scss
+++ b/_grandstand.scss
@@ -13,6 +13,7 @@
 @import 'lib/objects/faux-block-link';
 @import 'lib/objects/flag';
 @import 'lib/objects/icons';
+@import 'lib/objects/link';
 @import 'lib/objects/list-inline';
 @import 'lib/objects/list-ui';
 @import 'lib/objects/media';

--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,5 @@
   "dependencies": {
     "gs-sass-tools": "git@github.com:bbc/gs-sass-tools.git#^5.0.8"
   },
-  "version": "5.2.1"
+  "version": "5.3.0"
 }

--- a/lib/objects/_link.scss
+++ b/lib/objects/_link.scss
@@ -1,0 +1,15 @@
+/*------------------------------------*\
+    # LINK
+\*------------------------------------*/
+
+/**
+ * Commonly used link styles
+ */
+ 
+.gs-o-link {
+    text-decoration: none;
+    &:hover,
+    &:focus {
+        text-decoration: underline;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbc-grandstand",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "The BBC Grandstand CSS Framework is used by Sport, Live, News and Radio components",
   "main": "_grandstand.scss",
   "scripts": {


### PR DESCRIPTION
Adds a new 'link' object and a class for a link (a href) to be not underlined normally, and underlined on hover or focus. As this has been manually implemented a few times I feel it is worth adding to GS.

(Not associated with any JIRA ticket)